### PR TITLE
Add RcppParallel cxxflags to makevars

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,4 +1,5 @@
 PKG_CXXFLAGS += -DARMA_NO_DEBUG -DARMA_USE_BLAS \
                -DARMA_DONT_USE_OPENMP -DARMA_USE_TBB_ALLOC -DARMA_WARN_LEVEL=1
+PKG_CXXFLAGS += $(shell ${R_HOME}/bin/Rscript -e "RcppParallel::CxxFlags()")
 PKG_LIBS += $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) \
             $(shell ${R_HOME}/bin/Rscript -e "RcppParallel::RcppParallelLibs()")

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -2,5 +2,6 @@ PKG_CXXFLAGS += -DRCPP_PARALLEL_USE_TBB=1 \
                -DARMA_NO_DEBUG -DARMA_USE_BLAS -DARMA_DONT_USE_OPENMP \
                -DARMA_USE_TBB_ALLOC -DRCPP_PARALLEL_USE_TBB=1 \
                -DARMA_WARN_LEVEL=1
+PKG_CXXFLAGS += $(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" -e "RcppParallel::CxxFlags()")
 PKG_LIBS += $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) \
            $(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" -e "RcppParallel::RcppParallelLibs()")


### PR DESCRIPTION
This PR updates your Makevars to add RcppParallel's CXXFLAGS, which will be needed for compatibility with Windows ARM64