### PR TITLE
changed warning for convergence

### DIFF
--- a/R/fit.R
+++ b/R/fit.R
@@ -339,7 +339,7 @@ fit_glmpca_pois_main_loop <- function (LL, FF, Y, fixed_l, fixed_f,
                  loglik_const = loglik_const,
                  verbose = verbose)
   if (!res$convergence)
-    cat(sprintf(paste("Note that the specified convergence criteria was not",
+    message(sprintf(paste("Note that the specified convergence criteria was not",
                           "met within %d iterations."),
                     control$maxiter))
 

--- a/R/fit.R
+++ b/R/fit.R
@@ -339,9 +339,8 @@ fit_glmpca_pois_main_loop <- function (LL, FF, Y, fixed_l, fixed_f,
                  loglik_const = loglik_const,
                  verbose = verbose)
   if (!res$convergence)
-    warning(sprintf(paste("fit_glmpca_pois failed to meet convergence",
-                          "criterion within %d iterations.",
-                          "This may be okay for downstream tasks like clustering."),
+    cat(sprintf(paste("Note that the specified convergence criteria was not",
+                          "met within %d iterations."),
                     control$maxiter))
 
   # Prepare the output.

--- a/R/fit.R
+++ b/R/fit.R
@@ -340,7 +340,8 @@ fit_glmpca_pois_main_loop <- function (LL, FF, Y, fixed_l, fixed_f,
                  verbose = verbose)
   if (!res$convergence)
     warning(sprintf(paste("fit_glmpca_pois failed to meet convergence",
-                          "criterion within %d iterations"),
+                          "criterion within %d iterations.",
+                          "This may be okay for downstream tasks like clustering."),
                     control$maxiter))
 
   # Prepare the output.


### PR DESCRIPTION
@pcarbo I've received a few questions from people using fastglmpca about what to do when fastglmpca hasn't converged. Based on the new experiments in our paper, I think it's reasonable to suggest that it _might_ be okay to run clustering on a model that has not fully converged. What do you think?